### PR TITLE
Add build helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ chmod +x Scripts/setup.sh
 ./Scripts/setup.sh
 
 # 3. Build the project
-swift build -c release
+./Scripts/build.sh
 
 # 4. Run the automation server
-swift run XcodeAutomationServer --log-level debug --max-resource-utilization 85
+./Scripts/run.sh --log-level debug --max-resource-utilization 85
 ```
 
 ### First Automation

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+swift build -c release
+

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+swift run XcodeAutomationServer "$@"
+

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve Swift package dependencies and run a basic build/test cycle
+swift package resolve
+swift build
+swift test --parallel
+

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+swift test --parallel
+


### PR DESCRIPTION
## Summary
- add build helpers in `Scripts/`
- link them from the README

## Testing
- `swift test --parallel` *(fails: Invalid manifest)*

------
https://chatgpt.com/codex/tasks/task_e_683d07a610e08329a9ceb5eb32e0edc2