### PR TITLE
Add SECURITY policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,8 @@ Use the bug report template and include:
 - **Expected vs actual behavior**
 - **Performance impact** (if applicable)
 
+For security issues, please see [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
 ### Feature Requests
 Use the feature request template and include:
 - **Use case** and user story

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ swift build
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+For our security policy and vulnerability reporting guidelines, see [SECURITY.md](SECURITY.md).
 
 ## 🙏 Acknowledgments
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Sandbox Strategy
+- **App Sandbox**: All automation runs inside the macOS App Sandbox.
+- **User-controlled permissions**: File and network access require explicit approval using security bookmarks.
+- **Local processing**: Build data never leaves your machine unless explicitly configured.
+
+## Reporting a Vulnerability
+If you discover a security issue, please create a private GitHub security advisory or email `security@example.com`. We will respond as quickly as possible.


### PR DESCRIPTION
## Summary
- add SECURITY policy outlining sandbox strategy and disclosure process
- reference SECURITY policy from README
- reference SECURITY policy from CONTRIBUTING

## Testing
- `swift test` *(fails: Invalid manifest)*

------
https://chatgpt.com/codex/tasks/task_e_683d07ba6e748329b3395364e5b493aa