### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Display Swift version
+echo "Checking Swift version"
+swift --version
+
+# Display Xcode version if available
+echo "Checking Xcode version"
+if command -v xcodebuild >/dev/null 2>&1; then
+  xcodebuild -version
+else
+  echo "xcodebuild not found"
+fi
+
+# Resolve package dependencies
+echo "Resolving Swift package dependencies"
+swift package resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Codex Agent Instructions
+
+This repository includes a `.codex/setup.sh` script. The Codex environment automatically executes this script before running checks. It prints the Swift and Xcode versions and resolves dependencies using Swift Package Manager.


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for Swift/Xcode info and package resolution
- document automatic execution of the script in `AGENTS.md`

## Testing
- `bash .codex/setup.sh`
- `swift test --parallel` *(fails: Invalid manifest)*

------
https://chatgpt.com/codex/tasks/task_e_683d07bbca888329b36a9379ee67116e