### PR TITLE
Implement MCPError and replace placeholders

### DIFF
--- a/Sources/AutomationCore/Core/MCPError.swift
+++ b/Sources/AutomationCore/Core/MCPError.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Centralized error type for the automation platform.
+public enum MCPError: Error {
+    /// Feature or API has not been implemented yet.
+    case unimplemented
+    /// Provided project path or configuration is invalid.
+    case invalidProject(String)
+    /// Build process failed with the given reason.
+    case buildFailed(String)
+    /// Security policy was violated or permission denied.
+    case securityViolation(String)
+    /// Required system resources are unavailable.
+    case resourceExhausted
+    /// Arguments provided to a command are invalid.
+    case invalidArguments(String)
+}
+
+extension MCPError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unimplemented:
+            return "The requested functionality is not implemented."
+        case .invalidProject(let message):
+            return "Invalid project: \(message)"
+        case .buildFailed(let message):
+            return "Build failed: \(message)"
+        case .securityViolation(let message):
+            return "Security violation: \(message)"
+        case .resourceExhausted:
+            return "System resources are exhausted."
+        case .invalidArguments(let message):
+            return "Invalid arguments: \(message)"
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .unimplemented:
+            return "Update the application or check the documentation for upcoming features."
+        case .invalidProject:
+            return "Verify the project path and configuration."
+        case .buildFailed:
+            return "Inspect build logs for details and resolve any errors."
+        case .securityViolation:
+            return "Review security settings and required permissions."
+        case .resourceExhausted:
+            return "Reduce concurrent workload or free system resources."
+        case .invalidArguments:
+            return "Check the provided arguments for correctness."
+        }
+    }
+}
+
+extension MCPError: RecoverableError {
+    public var recoveryOptions: [String] { ["OK"] }
+
+    public func attemptRecovery(optionIndex: Int) -> Bool {
+        // No automatic recovery available yet.
+        false
+    }
+}

--- a/Sources/AutomationCore/ResourceManager/ResourceManager.swift
+++ b/Sources/AutomationCore/ResourceManager/ResourceManager.swift
@@ -16,13 +16,13 @@ public actor ResourceManager {
     /// Execute an operation while respecting resource limits.
     public func executeWithResourceControl<T>(_ operation: () async throws -> T) async throws -> T {
         logger.debug("executeWithResourceControl invoked")
-        throw MCPError.unimplemented
+        throw MCPError.resourceExhausted
     }
 
     /// Determine optimal simulator count given requested devices and optional limit.
     public func calculateOptimalSimulatorCount(requestedDevices: [SimulatorDevice], maxConcurrent: Int?) async throws -> Int {
         logger.debug("calculateOptimalSimulatorCount invoked")
-        throw MCPError.unimplemented
+        throw MCPError.resourceExhausted
     }
 
     /// Placeholder for resource optimization loop called by the server.

--- a/Sources/AutomationCore/SecurityFramework/SecurityManager.swift
+++ b/Sources/AutomationCore/SecurityFramework/SecurityManager.swift
@@ -15,19 +15,19 @@ public class SecurityManager {
     /// Validate that a project path is allowed for operations.
     public func validateProjectPath(_ path: String) throws {
         logger.debug("validateProjectPath invoked with \(path)")
-        throw MCPError.unimplemented
+        throw MCPError.invalidProject("Validation not implemented for path \(path)")
     }
 
     /// Variant used by the server for project creation specifically.
     public func validateProjectCreationPath(_ path: String) throws {
         logger.debug("validateProjectCreationPath invoked with \(path)")
-        throw MCPError.unimplemented
+        throw MCPError.invalidProject("Creation path validation not implemented for \(path)")
     }
 
     /// Request access to files with a specified purpose.
     public func requestFileAccess(paths: [String], purpose: AccessPurpose) async throws -> FileAccessResult {
         logger.debug("requestFileAccess invoked for \(paths)")
-        throw MCPError.unimplemented
+        throw MCPError.securityViolation("File access request not implemented")
     }
 }
 

--- a/Sources/AutomationCore/XcodeAutomationMCPServer.swift
+++ b/Sources/AutomationCore/XcodeAutomationMCPServer.swift
@@ -309,7 +309,7 @@ public final class XcodeAutomationMCPServer: Sendable {
         // Implementation of makefile-based build execution will use Swift
         // Subprocess for optimal performance. For now this method throws so
         // the server won't crash if it's called during early development.
-        throw MCPError.unimplemented
+        throw MCPError.buildFailed("Makefile-based build execution not implemented")
     }
     
     private func executeFileOperation(
@@ -320,7 +320,7 @@ public final class XcodeAutomationMCPServer: Sendable {
         // TODO: Secure file operations should integrate with the sandbox and
         // manage security-scoped bookmarks. Throwing here prevents a crash
         // until the implementation is provided.
-        throw MCPError.unimplemented
+        throw MCPError.securityViolation("Secure file operation not implemented")
     }
     
     private func handleMCPMessages(transport: any MCPTransport) async throws {


### PR DESCRIPTION
## Summary
- add `MCPError` enum with detailed cases and localized descriptions
- mark unimplemented functionality with specific errors instead of `.unimplemented`
- provide basic recovery suggestions via `RecoverableError`

## Testing
- `./Scripts/test.sh` *(fails: couldn't fetch Swift package dependencies without network)*

------
https://chatgpt.com/codex/tasks/task_e_683d17013db48329888ee1e48931f14c