### PR TITLE
Add MCP Tool Registry and extend SimpleMCPHandler

### DIFF
--- a/Sources/AutomationCore/MCP/MCPTool.swift
+++ b/Sources/AutomationCore/MCP/MCPTool.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Protocol representing an MCP tool that can handle requests and produce responses.
+public protocol MCPTool {
+    associatedtype Request: Codable
+    associatedtype Response: Codable
+
+    /// Name used to invoke this tool via JSON-RPC `method` field.
+    var name: String { get }
+
+    /// Handle a strongly typed request and return a response.
+    func handle(request: Request) async throws -> Response
+}
+
+/// Type-erased wrapper used by `MCPToolRegistry` to store heterogeneous tools.
+public struct AnyMCPTool {
+    public let name: String
+    private let handler: (Data) async throws -> Data
+
+    public init<T: MCPTool>(_ tool: T) {
+        self.name = tool.name
+        self.handler = { data in
+            let decoder = JSONDecoder()
+            let request = try decoder.decode(T.Request.self, from: data)
+            let response = try await tool.handle(request: request)
+            let encoder = JSONEncoder()
+            return try encoder.encode(response)
+        }
+    }
+
+    /// Execute the tool with raw JSON parameter data and return encoded result.
+    func handle(_ data: Data) async throws -> Data {
+        try await handler(data)
+    }
+}

--- a/Sources/AutomationCore/MCP/MCPToolRegistry.swift
+++ b/Sources/AutomationCore/MCP/MCPToolRegistry.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Registry storing available MCP tools.
+public actor MCPToolRegistry {
+    private var tools: [String: AnyMCPTool] = [:]
+
+    public init() {}
+
+    /// Register a new tool. Existing tool with the same name will be replaced.
+    public func register<T: MCPTool>(_ tool: T) {
+        tools[tool.name] = AnyMCPTool(tool)
+    }
+
+    /// Retrieve a registered tool by name.
+    public func tool(named name: String) -> AnyMCPTool? {
+        tools[name]
+    }
+}

--- a/Sources/AutomationCore/SimpleMCPHandler.swift
+++ b/Sources/AutomationCore/SimpleMCPHandler.swift
@@ -1,12 +1,76 @@
 import Foundation
 import Logging
 
+// MARK: - Simple MCP Handler with Tool Registry
+
 /// Simple MCP implementation to get started
 public final class SimpleMCPHandler {
     private let logger: Logger
+    private let registry: MCPToolRegistry
 
-    public init(logger: Logger) {
+    public init(logger: Logger, registry: MCPToolRegistry = MCPToolRegistry()) {
         self.logger = logger
+        self.registry = registry
+        // Register default tools asynchronously
+        Task { await self.registerDefaultTools() }
+    }
+
+    // MARK: - Tool Registration
+
+    private func registerDefaultTools() async {
+        await registry.register(BuildProjectTool(handler: self))
+        await registry.register(ListSimulatorsTool(logger: logger))
+        await registry.register(GetProjectInfoTool(logger: logger))
+        await registry.register(ValidateProjectTool())
+    }
+
+    // MARK: - JSON-RPC Handling
+
+    /// Handle a JSON-RPC encoded request and route it to the appropriate tool.
+    public func handleMessage(_ data: Data) async -> Data {
+        do {
+            guard
+                let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let method = object["method"] as? String
+            else {
+                return errorResponse(id: nil, code: -32600, message: "Invalid request")
+            }
+
+            let id = object["id"] as? Int
+            let paramsData: Data
+            if let params = object["params"] {
+                paramsData = try JSONSerialization.data(withJSONObject: params)
+            } else {
+                paramsData = Data("{}".utf8)
+            }
+
+            guard let tool = await registry.tool(named: method) else {
+                return errorResponse(id: id, code: -32601, message: "Method not found")
+            }
+
+            let resultData = try await tool.handle(paramsData)
+            return successResponse(id: id, result: resultData)
+        } catch {
+            return errorResponse(id: nil, code: -32000, message: error.localizedDescription)
+        }
+    }
+
+    private func successResponse(id: Int?, result: Data) -> Data {
+        var response: [String: Any] = ["jsonrpc": "2.0"]
+        if let id = id { response["id"] = id }
+        if let resultObject = try? JSONSerialization.jsonObject(with: result) {
+            response["result"] = resultObject
+        }
+        return (try? JSONSerialization.data(withJSONObject: response)) ?? Data()
+    }
+
+    private func errorResponse(id: Int?, code: Int, message: String) -> Data {
+        var response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "error": ["code": code, "message": message]
+        ]
+        if let id = id { response["id"] = id }
+        return (try? JSONSerialization.data(withJSONObject: response)) ?? Data()
     }
 
     /// Handle a basic build request and run xcodebuild.
@@ -61,4 +125,106 @@ public struct SimpleBuildResponse: Codable {
     public let success: Bool
     public let stdout: String
     public let stderr: String
+}
+
+// MARK: - Additional Tool Requests/Responses
+
+struct ListSimulatorsRequest: Codable {}
+struct ListSimulatorsResponse: Codable {
+    let simulators: [SimulatorDevice]
+}
+
+struct GetProjectInfoRequest: Codable { let projectPath: String }
+struct GetProjectInfoResponse: Codable { let schemes: [String] }
+
+struct ValidateProjectRequest: Codable { let projectPath: String }
+struct ValidateProjectResponse: Codable { let valid: Bool; let message: String }
+
+// MARK: - MCP Tool Implementations
+
+struct BuildProjectTool: MCPTool {
+    typealias Request = SimpleBuildRequest
+    typealias Response = SimpleBuildResponse
+
+    let handler: SimpleMCPHandler
+    var name: String { "build_project" }
+
+    func handle(request: SimpleBuildRequest) async throws -> SimpleBuildResponse {
+        try await handler.handleBuildRequest(request)
+    }
+}
+
+struct ListSimulatorsTool: MCPTool {
+    struct Request: Codable {}
+    typealias Response = ListSimulatorsResponse
+
+    let logger: Logger
+    var name: String { "list_simulators" }
+
+    func handle(request: Request) async throws -> ListSimulatorsResponse {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["simctl", "list", "devices", "available", "-j"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        var result: [SimulatorDevice] = []
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let devices = json["devices"] as? [String: Any] {
+            for (runtime, value) in devices {
+                if let list = value as? [[String: Any]] {
+                    for dev in list {
+                        guard (dev["isAvailable"] as? Bool) == true else { continue }
+                        if let name = dev["name"] as? String,
+                           let udid = dev["udid"] as? String {
+                            let type = dev["deviceTypeIdentifier"] as? String ?? ""
+                            result.append(SimulatorDevice(id: udid, name: name, runtime: runtime, deviceType: type))
+                        }
+                    }
+                }
+            }
+        }
+        return ListSimulatorsResponse(simulators: result)
+    }
+}
+
+struct GetProjectInfoTool: MCPTool {
+    typealias Request = GetProjectInfoRequest
+    typealias Response = GetProjectInfoResponse
+
+    let logger: Logger
+    var name: String { "get_project_info" }
+
+    func handle(request: GetProjectInfoRequest) async throws -> GetProjectInfoResponse {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcodebuild")
+        process.arguments = ["-list", "-json", "-project", request.projectPath]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let project = json["project"] as? [String: Any],
+           let schemes = project["schemes"] as? [String] {
+            return GetProjectInfoResponse(schemes: schemes)
+        }
+        return GetProjectInfoResponse(schemes: [])
+    }
+}
+
+struct ValidateProjectTool: MCPTool {
+    typealias Request = ValidateProjectRequest
+    typealias Response = ValidateProjectResponse
+
+    var name: String { "validate_project" }
+
+    func handle(request: ValidateProjectRequest) async throws -> ValidateProjectResponse {
+        let exists = FileManager.default.fileExists(atPath: request.projectPath)
+        let message = exists ? "Project exists" : "Project not found"
+        return ValidateProjectResponse(valid: exists, message: message)
+    }
 }


### PR DESCRIPTION
## Summary
- introduce `MCPTool` protocol and `AnyMCPTool` wrapper
- add `MCPToolRegistry` actor for registering tools
- expand `SimpleMCPHandler` to use registry and dispatch JSON‑RPC requests
- implement tools for `build_project`, `list_simulators`, `get_project_info` and `validate_project`

## Testing
- `swift test -l` *(fails: couldn't clone dependencies)*
- `swift build --target AutomationCore -c debug` *(fails: couldn't clone dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683d171c13fc8329841c14e3997106c3