### PR TITLE
Implement core security validation

### DIFF
--- a/Sources/AutomationCore/SecurityFramework/PathValidator.swift
+++ b/Sources/AutomationCore/SecurityFramework/PathValidator.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Utility for validating and resolving filesystem paths.
+public struct PathValidator {
+    private let allowedDirectories: [String]
+
+    public init(allowedDirectories: [String]) {
+        self.allowedDirectories = allowedDirectories.map {
+            URL(fileURLWithPath: $0).standardizedFileURL.path
+        }
+    }
+
+    /// Resolve symlinks and standardize a path.
+    public func resolvedPath(for path: String) throws -> String {
+        let url = URL(fileURLWithPath: path)
+        return url.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    /// Check for path traversal components ("..") after standardization.
+    public func isTraversalSafe(_ path: String) -> Bool {
+        !URL(fileURLWithPath: path).standardized.pathComponents.contains("..")
+    }
+
+    /// Ensure the path resides within one of the allowed directories.
+    public func isWhitelisted(_ path: String) -> Bool {
+        let resolved = (try? resolvedPath(for: path)) ?? path
+        return allowedDirectories.contains { resolved.hasPrefix($0) }
+    }
+}

--- a/Sources/AutomationCore/SecurityFramework/SandboxManager.swift
+++ b/Sources/AutomationCore/SecurityFramework/SandboxManager.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Logging
+
+/// Handles App Sandbox preparation. Currently a placeholder for future phases.
+public final class SandboxManager {
+    private let logger: Logger
+
+    public init(logger: Logger) {
+        self.logger = logger
+    }
+
+    /// Perform minimal sandbox preparation.
+    public func prepareSandbox() {
+        logger.debug("Preparing App Sandbox (stub)")
+        // Future: configure security scoped bookmarks and entitlements
+    }
+}

--- a/Sources/AutomationCore/SecurityFramework/SecurityManager.swift
+++ b/Sources/AutomationCore/SecurityFramework/SecurityManager.swift
@@ -1,21 +1,43 @@
 import Foundation
 import Logging
 
+/// Errors that can occur during security validation.
+public enum SecurityError: Error, Sendable {
+    case pathTraversalDetected
+    case unauthorizedDirectory
+    case permissionDenied
+}
+
 /// Manages security-related operations such as validating project paths and requesting
 /// user permissions for file access.
 public class SecurityManager {
     private let maximumSecurity: Bool
     private let logger: Logger
+    private let pathValidator: PathValidator
+    private let sandboxManager: SandboxManager
 
     public init(maximumSecurity: Bool, logger: Logger) throws {
         self.maximumSecurity = maximumSecurity
         self.logger = logger
+        self.pathValidator = PathValidator(allowedDirectories: [FileManager.default.currentDirectoryPath])
+        self.sandboxManager = SandboxManager(logger: logger)
+        self.sandboxManager.prepareSandbox()
     }
 
     /// Validate that a project path is allowed for operations.
     public func validateProjectPath(_ path: String) throws {
         logger.debug("validateProjectPath invoked with \(path)")
-        throw MCPError.unimplemented
+        let resolved = try pathValidator.resolvedPath(for: path)
+
+        guard pathValidator.isTraversalSafe(resolved) else {
+            logger.warning("Path traversal detected for \(path)")
+            throw SecurityError.pathTraversalDetected
+        }
+
+        guard pathValidator.isWhitelisted(resolved) else {
+            logger.warning("Path \(resolved) not within allowed directories")
+            throw SecurityError.unauthorizedDirectory
+        }
     }
 
     /// Variant used by the server for project creation specifically.
@@ -27,7 +49,51 @@ public class SecurityManager {
     /// Request access to files with a specified purpose.
     public func requestFileAccess(paths: [String], purpose: AccessPurpose) async throws -> FileAccessResult {
         logger.debug("requestFileAccess invoked for \(paths)")
-        throw MCPError.unimplemented
+
+        var granted: [String] = []
+        var bookmarks: [SecurityBookmark] = []
+
+        for path in paths {
+            let resolved = try pathValidator.resolvedPath(for: path)
+
+            guard pathValidator.isTraversalSafe(resolved) else {
+                logger.warning("Path traversal detected for \(path)")
+                throw SecurityError.pathTraversalDetected
+            }
+
+            if pathValidator.isWhitelisted(resolved) {
+                granted.append(resolved)
+                continue
+            }
+
+            guard await requestUserPermission(for: resolved, purpose: purpose) else {
+                throw SecurityError.permissionDenied
+            }
+
+            granted.append(resolved)
+            bookmarks.append(SecurityBookmark(url: URL(fileURLWithPath: resolved)))
+        }
+
+        return FileAccessResult(grantedPaths: granted, bookmarks: bookmarks)
+    }
+
+    // MARK: - Private Helpers
+
+    private func requestUserPermission(for path: String, purpose: AccessPurpose) async -> Bool {
+        print("Allow access to \(path) for \(describe(purpose))? [y/N] ", terminator: "")
+        guard let response = readLine() else { return false }
+        return response.lowercased().hasPrefix("y")
+    }
+
+    private func describe(_ purpose: AccessPurpose) -> String {
+        switch purpose {
+        case .buildAnalysis:
+            return "build analysis"
+        case .projectCreation:
+            return "project creation"
+        case .custom(let value):
+            return value
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add PathValidator for basic path checking
- add SandboxManager placeholder
- implement SecurityManager validation and permission logic

## Status: MERGED MANUALLY TO MAIN
This PR had merge conflicts but contained excellent security code aligned with the PRD.
Changes have been manually applied to main branch.

------
https://chatgpt.com/codex/tasks/task_e_683d172e28048329a288de208c3f58bc