### PR TITLE
Add task markdown files and agent workflow notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,20 @@ The project is automatically configured for AI agents through the `.codex/setup.
 3. **Testing**: Use `./Scripts/test.sh` for comprehensive testing
 4. **Development**: Follow the Phase-based development timeline in the PRD
 
+## Task Workflow
+
+The outstanding work items for Phase 1 are split into separate markdown files
+under `Documentation/Tasks`. Agents should pick up the lowest numbered
+`TaskXX_*.md` file that has not yet been implemented. After completing the
+implementation for that task:
+
+1. Run `./Scripts/build.sh` and `./Scripts/test.sh` to validate the changes.
+2. Commit the results with a concise message referencing the task.
+3. Proceed to the next numbered task file and repeat the process.
+
+This ensures tasks are handled sequentially with build and test verification
+between each step.
+
 ## Project Structure
 
 - `Sources/AutomationCore/` - Core automation framework

--- a/Documentation/Tasks/Task06_XcodeBuildWrapper.md
+++ b/Documentation/Tasks/Task06_XcodeBuildWrapper.md
@@ -1,0 +1,30 @@
+### Task 6: Implement XcodeBuild Wrapper with Enhanced Output Parsing
+**Priority:** HIGH - Core build functionality
+
+**Description:** Create a comprehensive wrapper around `xcodebuild` that provides structured output parsing and real-time feedback.
+
+**Files to Create:**
+- `Sources/AutomationCore/Build/XcodeBuildWrapper.swift`
+- `Sources/AutomationCore/Build/BuildOutputParser.swift`
+
+**Files to Modify:**
+- `Sources/AutomationCore/SimpleMCPHandler.swift`
+
+**Specific Actions:**
+1. Create `XcodeBuildWrapper` class that:
+   - Handles all `xcodebuild` operations (build, test, archive, analyze)
+   - Provides real-time output streaming
+   - Implements proper process management with cancellation
+2. Implement `BuildOutputParser` that extracts:
+   - Compilation errors and warnings
+   - Build timing information
+   - Success/failure status
+   - Performance metrics
+3. Replace basic `Process` usage in `SimpleMCPHandler`
+4. Add support for multiple schemes and destinations
+
+**Acceptance Criteria:**
+- Real-time build output streaming
+- Structured error/warning extraction
+- Support for all major `xcodebuild` operations
+- Proper process cleanup and cancellation

--- a/Documentation/Tasks/Task07_SimulatorManagement.md
+++ b/Documentation/Tasks/Task07_SimulatorManagement.md
@@ -1,0 +1,27 @@
+### Task 7: Implement Simulator Management System
+**Priority:** HIGH - Multi-simulator support
+
+**Description:** Create comprehensive simulator management capabilities using `simctl` with support for concurrent operations.
+
+**Files to Create:**
+- `Sources/AutomationCore/Simulator/SimulatorManager.swift`
+- `Sources/AutomationCore/Simulator/SimCtlWrapper.swift`
+
+**Specific Actions:**
+1. Implement `SimCtlWrapper` for all `simctl` operations:
+   - List available devices
+   - Boot/shutdown simulators
+   - Install/uninstall apps
+   - Take screenshots
+   - Manage device state
+2. Create `SimulatorManager` actor for concurrent operations:
+   - Resource-aware simulator launching
+   - Automatic cleanup and management
+   - Health monitoring and recovery
+3. Integrate with `ResourceManager` for optimal device allocation
+4. Add MCP tools for simulator operations
+
+**Acceptance Criteria:**
+- Can manage 6+ simulators concurrently
+- Automatic resource allocation and cleanup
+- Full `simctl` feature coverage through Swift API

--- a/Documentation/Tasks/Task08_BuildIntelligenceEngine.md
+++ b/Documentation/Tasks/Task08_BuildIntelligenceEngine.md
@@ -1,0 +1,27 @@
+### Task 8: Create Build Intelligence Engine Foundation
+**Priority:** MEDIUM - Real-time analysis
+
+**Description:** Implement the foundation for real-time build analysis and error detection as outlined in the PRD.
+
+**Files to Create:**
+- `Sources/AutomationCore/Intelligence/BuildIntelligenceEngine.swift`
+- `Sources/AutomationCore/Intelligence/ErrorAnalyzer.swift`
+- `Sources/AutomationCore/Intelligence/BuildMetricsCollector.swift`
+
+**Specific Actions:**
+1. Implement `BuildIntelligenceEngine` actor with:
+   - Real-time log monitoring using `DispatchSource`
+   - Pattern matching for common build errors
+   - Performance metrics collection
+2. Create `ErrorAnalyzer` for intelligent error categorization:
+   - Syntax errors
+   - Dependency issues
+   - Configuration problems
+   - Resource constraints
+3. Add `BuildMetricsCollector` for performance tracking
+4. Integrate with `XcodeBuildWrapper` for real-time analysis
+
+**Acceptance Criteria:**
+- Sub-5-second error detection from build start
+- Categorized error analysis with suggested fixes
+- Performance metrics collection and reporting

--- a/Documentation/Tasks/Task09_FileSystemMonitoring.md
+++ b/Documentation/Tasks/Task09_FileSystemMonitoring.md
@@ -1,0 +1,25 @@
+### Task 9: Implement File System Monitoring
+**Priority:** MEDIUM - Real-time change detection
+
+**Description:** Create file system monitoring capabilities to detect project changes in real-time for proactive build intelligence.
+
+**Files to Create:**
+- `Sources/AutomationCore/FileSystem/FileSystemMonitor.swift`
+- `Sources/AutomationCore/FileSystem/ProjectWatcher.swift`
+
+**Specific Actions:**
+1. Implement `FileSystemMonitor` using `DispatchSource`:
+   - Monitor Swift source files for changes
+   - Watch project configuration files
+   - Track build artifacts and derived data
+2. Create `ProjectWatcher` actor for project-specific monitoring:
+   - Smart filtering of relevant changes
+   - Debouncing rapid changes
+   - Change categorization (source, config, resources)
+3. Integrate with `BuildIntelligenceEngine` for proactive analysis
+4. Add configurable monitoring rules
+
+**Acceptance Criteria:**
+- Real-time file change detection with <100ms latency
+- Smart filtering to ignore irrelevant changes
+- Integration with build intelligence for proactive analysis

--- a/Documentation/Tasks/Task10_PerformanceBenchmarking.md
+++ b/Documentation/Tasks/Task10_PerformanceBenchmarking.md
@@ -1,0 +1,25 @@
+### Task 10: Create Performance Benchmarking System
+**Priority:** MEDIUM - Optimization tracking
+
+**Description:** Implement performance benchmarking to track build times, resource usage, and identify optimization opportunities.
+
+**Files to Create:**
+- `Sources/AutomationCore/Performance/BenchmarkRunner.swift`
+- `Sources/AutomationCore/Performance/PerformanceProfiler.swift`
+
+**Specific Actions:**
+1. Implement `BenchmarkRunner` for standardized performance testing:
+   - Build time measurements
+   - Resource usage profiling
+   - Comparative analysis over time
+2. Create `PerformanceProfiler` for detailed profiling:
+   - CPU usage during builds
+   - Memory allocation patterns
+   - Disk I/O analysis
+3. Add baseline establishment for Mac Studio M2 Max
+4. Create MCP tools for performance analysis
+
+**Acceptance Criteria:**
+- Automated performance benchmarking
+- Historical performance tracking
+- Identification of performance regressions

--- a/Documentation/Tasks/Task11_XcodeMakePattern.md
+++ b/Documentation/Tasks/Task11_XcodeMakePattern.md
@@ -1,0 +1,25 @@
+### Task 11: Extract XcodeBuildMCP xcodemake Pattern
+**Priority:** HIGH - Performance improvement
+
+**Description:** Research and implement the xcodemake algorithm pattern from XcodeBuildMCP for ultra-fast incremental builds as mentioned in the PRD.
+
+**Files to Create:**
+- `Sources/AutomationCore/Build/XcodeMakeGenerator.swift`
+- `Sources/AutomationCore/Build/IncrementalBuildManager.swift`
+
+**Specific Actions:**
+1. Research XcodeBuildMCP's xcodemake implementation approach
+2. Implement `XcodeMakeGenerator` that:
+   - Analyzes Xcode project dependencies
+   - Generates optimized Makefiles for incremental builds
+   - Handles complex target dependencies
+3. Create `IncrementalBuildManager` for:
+   - Dependency tracking
+   - Selective compilation
+   - Build artifact caching
+4. Integrate with `XcodeBuildWrapper` for 10x performance improvement
+
+**Acceptance Criteria:**
+- Generate functional Makefiles from Xcode projects
+- 10x faster incremental builds compared to standard xcodebuild
+- Proper dependency tracking and invalidation

--- a/Documentation/Tasks/Task12_ProjectManagementPatterns.md
+++ b/Documentation/Tasks/Task12_ProjectManagementPatterns.md
@@ -1,0 +1,25 @@
+### Task 12: Extract r-huijts Project Management Patterns
+**Priority:** MEDIUM - Project manipulation
+
+**Description:** Extract and enhance the project management patterns from `r-huijts/xcode-mcp-server` for creating and modifying Xcode projects.
+
+**Files to Create:**
+- `Sources/AutomationCore/Project/XcodeProjectManager.swift`
+- `Sources/AutomationCore/Project/PbxprojParser.swift`
+
+**Specific Actions:**
+1. Study r-huijts project management implementation
+2. Implement `PbxprojParser` for:
+   - Reading and parsing .pbxproj files
+   - Safe modification of project structure
+   - Adding files and targets to projects
+3. Create `XcodeProjectManager` for high-level operations:
+   - Project creation from templates
+   - File addition and organization
+   - Target configuration management
+4. Add MCP tools for project manipulation
+
+**Acceptance Criteria:**
+- Safe .pbxproj file manipulation
+- Project creation from standard templates
+- File and target management capabilities

--- a/Documentation/Tasks/Task13_UIAutomationFramework.md
+++ b/Documentation/Tasks/Task13_UIAutomationFramework.md
@@ -1,0 +1,25 @@
+### Task 13: Implement Enhanced UI Automation Framework
+**Priority:** MEDIUM - Testing capabilities
+
+**Description:** Create native UI automation capabilities that surpass `idb_companion` by leveraging Swift's native Accessibility APIs.
+
+**Files to Create:**
+- `Sources/AutomationCore/UIAutomation/AccessibilityAutomation.swift`
+- `Sources/AutomationCore/UIAutomation/UITestExecutor.swift`
+
+**Specific Actions:**
+1. Implement `AccessibilityAutomation` using native APIs:
+   - Direct `AXUIElement` manipulation
+   - Coordinate-based interactions
+   - Element discovery and inspection
+2. Create `UITestExecutor` for complex scenarios:
+   - Multi-step test execution
+   - Screenshot capture integration
+   - Performance measurement during tests
+3. Add support for both simulator and device automation
+4. Create MCP tools for UI automation operations
+
+**Acceptance Criteria:**
+- Native accessibility API integration
+- More reliable than idb_companion-based solutions
+- Support for complex multi-step UI scenarios

--- a/Documentation/Tasks/Task14_AdvancedLogging.md
+++ b/Documentation/Tasks/Task14_AdvancedLogging.md
@@ -1,0 +1,25 @@
+### Task 14: Implement Advanced Logging and Analytics
+**Priority:** MEDIUM - Observability
+
+**Description:** Create comprehensive logging and analytics system for build operations, performance tracking, and debugging.
+
+**Files to Create:**
+- `Sources/AutomationCore/Logging/AdvancedLogger.swift`
+- `Sources/AutomationCore/Analytics/AnalyticsCollector.swift`
+
+**Specific Actions:**
+1. Implement `AdvancedLogger` with:
+   - Structured logging with metadata
+   - Log aggregation and filtering
+   - Real-time log streaming for MCP clients
+2. Create `AnalyticsCollector` for:
+   - Build success/failure rates
+   - Performance trend analysis
+   - Resource utilization patterns
+3. Add privacy-preserving analytics (no data leaves machine)
+4. Integrate with all major system components
+
+**Acceptance Criteria:**
+- Comprehensive structured logging
+- Privacy-preserving analytics collection
+- Real-time log streaming capabilities

--- a/Documentation/Tasks/Task15_DependencyManagement.md
+++ b/Documentation/Tasks/Task15_DependencyManagement.md
@@ -1,0 +1,25 @@
+### Task 15: Create Dependency Management Integration
+**Priority:** LOW - Enhanced capabilities
+
+**Description:** Add support for managing Swift Package Manager and CocoaPods dependencies programmatically.
+
+**Files to Create:**
+- `Sources/AutomationCore/Dependencies/SPMManager.swift`
+- `Sources/AutomationCore/Dependencies/CocoaPodsManager.swift`
+
+**Specific Actions:**
+1. Implement `SPMManager` for Swift Package Manager:
+   - Package resolution and updates
+   - Dependency analysis
+   - `Package.swift` manipulation
+2. Create `CocoaPodsManager` for CocoaPods:
+   - Podfile analysis and modification
+   - Pod installation and updates
+   - Dependency conflict resolution
+3. Add MCP tools for dependency operations
+4. Integrate with project management system
+
+**Acceptance Criteria:**
+- Full SPM and CocoaPods support
+- Dependency conflict detection and resolution
+- Integration with build system

--- a/Documentation/Tasks/Task16_UnitTests.md
+++ b/Documentation/Tasks/Task16_UnitTests.md
@@ -1,0 +1,29 @@
+### Task 16: Implement Comprehensive Unit Tests
+**Priority:** HIGH - Code quality
+
+**Description:** Create comprehensive unit tests for all core components to ensure reliability and enable safe refactoring.
+
+**Files to Create:**
+- `Tests/AutomationCoreTests/SimpleMCPHandlerTests.swift`
+- `Tests/AutomationCoreTests/SecurityManagerTests.swift`
+- `Tests/AutomationCoreTests/ResourceManagerTests.swift`
+
+**Specific Actions:**
+1. Add unit tests for `SimpleMCPHandler`:
+   - Request/response parsing
+   - Error handling scenarios
+   - Tool registry functionality
+2. Test `SecurityManager` path validation:
+   - Path traversal prevention
+   - Permission system validation
+   - Sandbox compliance
+3. Test `ResourceManager` resource allocation:
+   - Dynamic allocation algorithms
+   - Resource constraint handling
+   - Concurrent operation management
+4. Add test utilities and mocking frameworks
+
+**Acceptance Criteria:**
+- 80%+ code coverage for core components
+- All security-critical paths tested
+- Performance regression testing

--- a/Documentation/Tasks/Task17_IntegrationTests.md
+++ b/Documentation/Tasks/Task17_IntegrationTests.md
@@ -1,0 +1,25 @@
+### Task 17: Create Integration Test Suite
+**Priority:** HIGH - System validation
+
+**Description:** Build integration tests that validate end-to-end workflows and MCP protocol compliance.
+
+**Files to Create:**
+- `Tests/IntegrationTests/MCPServerIntegrationTests.swift`
+- `Tests/IntegrationTests/BuildWorkflowTests.swift`
+
+**Specific Actions:**
+1. Create MCP protocol integration tests:
+   - Full request/response cycles
+   - Tool invocation validation
+   - Error scenario handling
+2. Add build workflow tests:
+   - Complete build cycles
+   - Multi-project scenarios
+   - Resource management validation
+3. Test simulator management integration
+4. Add performance benchmarking in tests
+
+**Acceptance Criteria:**
+- End-to-end workflow validation
+- MCP protocol compliance verification
+- Performance benchmark validation

--- a/Documentation/Tasks/Task18_ConfigurationManagement.md
+++ b/Documentation/Tasks/Task18_ConfigurationManagement.md
@@ -1,0 +1,26 @@
+### Task 18: Implement Configuration Management System
+**Priority:** MEDIUM - Flexibility
+
+**Description:** Create a configuration system to allow customization of server behavior, resource limits, and feature toggles.
+
+**Files to Create:**
+- `Sources/AutomationCore/Configuration/ServerConfiguration.swift`
+- `Sources/AutomationCore/Configuration/ConfigurationLoader.swift`
+
+**Specific Actions:**
+1. Define `ServerConfiguration` struct with:
+   - Resource utilization limits
+   - Security policy settings
+   - Feature toggle flags
+   - Logging configuration
+2. Implement `ConfigurationLoader` for:
+   - JSON/YAML configuration file support
+   - Environment variable override
+   - Runtime configuration updates
+3. Integrate configuration throughout the system
+4. Add validation and default fallbacks
+
+**Acceptance Criteria:**
+- Flexible configuration system
+- Runtime configuration updates
+- Comprehensive validation and defaults

--- a/Documentation/Tasks/Task19_DocumentationGeneration.md
+++ b/Documentation/Tasks/Task19_DocumentationGeneration.md
@@ -1,0 +1,25 @@
+### Task 19: Add Documentation Generation System
+**Priority:** MEDIUM - Developer experience
+
+**Description:** Implement automated documentation generation for MCP tools and API usage.
+
+**Files to Create:**
+- `Sources/AutomationCore/Documentation/DocGenerator.swift`
+- `Sources/AutomationCore/Documentation/MCPToolDocumenter.swift`
+
+**Specific Actions:**
+1. Create `DocGenerator` for:
+   - Automatic API documentation
+   - MCP tool reference generation
+   - Usage example creation
+2. Implement `MCPToolDocumenter` for:
+   - Tool capability documentation
+   - Parameter validation and examples
+   - Response format documentation
+3. Add markdown generation for GitHub integration
+4. Create MCP tools for documentation queries
+
+**Acceptance Criteria:**
+- Automated API documentation
+- Comprehensive MCP tool documentation
+- Integration with development workflow

--- a/Documentation/Tasks/Task20_HealthMonitoring.md
+++ b/Documentation/Tasks/Task20_HealthMonitoring.md
@@ -1,0 +1,25 @@
+### Task 20: Implement Health Monitoring and Diagnostics
+**Priority:** LOW - Operations
+
+**Description:** Create health monitoring and diagnostic capabilities to ensure system reliability and performance.
+
+**Files to Create:**
+- `Sources/AutomationCore/Health/HealthMonitor.swift`
+- `Sources/AutomationCore/Diagnostics/SystemDiagnostics.swift`
+
+**Specific Actions:**
+1. Implement `HealthMonitor` actor for:
+   - System health checks
+   - Resource usage monitoring
+   - Component status tracking
+2. Create `SystemDiagnostics` for:
+   - Performance analysis
+   - Problem detection and reporting
+   - System optimization suggestions
+3. Add health endpoints for MCP clients
+4. Implement automatic recovery mechanisms
+
+**Acceptance Criteria:**
+- Comprehensive system health monitoring
+- Proactive problem detection
+- Automatic recovery for common issues


### PR DESCRIPTION
## Summary
- document Build Intelligence tasks into separate `Documentation/Tasks` md files
- note in `AGENTS.md` how agents should grab next task and run build/test

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683d4df5d6e48329bddc7a282eb4bd7c